### PR TITLE
fix: case-insensitive LOG_LEVEL env var

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -9,7 +9,9 @@ LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
 class LoggerSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env", case_sensitive=False, extra="ignore"
+    )
 
     log_level: LogLevel = "INFO"
 


### PR DESCRIPTION
## Summary
- Added `case_sensitive=False` to LoggerSettings
- LOG_LEVEL env var now case-insensitive, matching Settings pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)